### PR TITLE
Implement client timeout

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -68,6 +68,13 @@ function Client(options, isSecure) {
     }
   }
 
+  // only allow numeric timeouts
+  if (typeof options.timeout !== 'number' &&
+    typeof options.timeout !== 'undefined')
+  {
+    delete options.timeout
+  }
+
   options.method = 'POST'
   this.options = options
 
@@ -115,8 +122,31 @@ Client.prototype.methodCall = function methodCall(method, params, callback) {
   }.bind(this))
 
   request.on('error', callback)
+
+  // if a timeout is specified, abort the request after the given time.
+  if (options.timeout) {
+    request.setTimeout(options.timeout,
+      Client._timeoutHandler(request, callback))
+  }
+
   request.write(xml, 'utf8')
   request.end()
+}
+
+Client._timeoutHandler = function (request, callback) {
+  return function () {
+    var needsCallback = !request.res && !request._hadError
+
+    // make sure the socket doesn't send an 'error' event
+    if (needsCallback) request._hadError = true
+
+    //abort the request
+    request.abort()
+
+    // send the calback only if it wont be sent from elsewhere
+    if (needsCallback) callback(new Error('socket timed out'))
+
+  }
 }
 
 /**

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -309,6 +309,28 @@ vows.describe('Client').addBatch({
         assert.equal(value, 'a=b')
       }
     }
-
+  , 'with a timeout set' : {
+      topic: function () {
+        var that = this
+        http.createServer(function(request, response) {
+          setTimeout(function () {
+            response.writeHead(200, {'Content-Type': 'text/xml'})
+            var data = '<?xml version="2.0" encoding="UTF-8"?>'
+              + '<methodResponse>'
+              + '<params></params>'
+              + '</methodResponse>'
+            response.write(data)
+            response.end()
+          }, 10000)
+        }).listen(9097, 'localhost', function() {
+          var client = new Client({ host: 'localhost', port: 9097, path: '/', timeout: 100}, false)
+          client.methodCall('any', null, function (error) {that.callback(error)})
+        })
+      }
+    , 'return timeout Error' : function (error, value) {
+        assert.isObject(error)
+        assert.equal(error.message, 'socket timed out')
+      }
+    }
   }
 }).export(module)


### PR DESCRIPTION
Realization of issue #73. When a socket times out and no other
errors have occured yet, callback will be called with an error.